### PR TITLE
fix url

### DIFF
--- a/includes/class-mojito-sinpe-gateway.php
+++ b/includes/class-mojito-sinpe-gateway.php
@@ -168,7 +168,8 @@ class Mojito_Sinpe_Gateway extends WC_Payment_Gateway {
 		}
 
 		/*
-		URL: https://www.bccr.fi.cr/sistema-de-pagos/informaci%C3%B3n-general/tarifas-y-comisiones-del-sinpe/comisiones-cobradas-por-las-entidades-financieras/sinpe-m%C3%B3vil
+		Note: Web Archive URL. The real url was removed from Central Bank's SINPE official documentation.
+		URL: https://web.archive.org/web/20210824000600/https://www.bccr.fi.cr/sistema-de-pagos/informaci%C3%B3n-general/tarifas-y-comisiones-del-sinpe/comisiones-cobradas-por-las-entidades-financieras/sinpe-m%C3%B3vil
 		*/
 		$sinpe_banks = array(
 			'none'            => __( 'Select your bank', 'mojito-sinpe' ),


### PR DESCRIPTION
El banco bajó el URL donde venían los números de teléfono. Agregué el link del Wayback Machine. 

Por cierto, aprovecho este PR para ponerme en contacto con usted. Qué buen plugin, mae... y el código demasiado ordenado. Lastimosamente no sé PHP y aunque intenté entenderlo hay cosas que simplemente no entiendo de dónde vienen. Yo hace poco empecé a escribir código en Javascript y Python principalmente. Le escribo para ver si no le interesaría hacer una implementación en **Javascript** de este plugin fuera de WordPress? Yo me apunto a bretear y sacamos algo tuanis. No soy pro pero tengo tiempo y dedicación.

Le dejo mi discord: amilkar#8941 por cualquier vara

PD: Y si no tiene tiempo pero tiene docs de las clases y funciones de este plugin en texto plano también esos papeles son bienvenidos, bro! Pura vida.